### PR TITLE
Update to upstream: Add Tagger Script support to the code highlighter. (#68)

### DIFF
--- a/markdownhighlighter.h
+++ b/markdownhighlighter.h
@@ -156,8 +156,9 @@ public:
         CodeTypeScriptComment = 233,
         CodeYAML = 234,
         CodeINI = 236,
-        CodeVex = 238,
-        CodeVexComment = 239,
+        CodeTaggerScript = 238,
+        CodeVex = 240,
+        CodeVexComment = 241,
     };
     Q_ENUMS(HighlighterState)
 
@@ -176,7 +177,6 @@ public:
     void clearDirtyBlocks();
     void setHighlightingOptions(const HighlightingOptions options);
     void initHighlightingRules();
-
 signals:
     void highlightingFinished();
 
@@ -222,6 +222,8 @@ protected:
     void cssHighlighter(const QString &text);
 
     void xmlHighlighter(const QString &text);
+
+    void taggerScriptHighlighter(const QString &text);
 
     void highlightFrontmatterBlock(const QString& text);
 


### PR DESCRIPTION
* Declare taggerScriptHighlighter

* Create empty method

* Add TaggerScript to language list

* Add TaggerScript to language init

* loop

* Add functions highlighter

* Add variable highlighter

* Add comment highlighter

* Add escape sequence highlighter

* Add doc

* Move everything to the top (oops)

* Changed manual +1 for a variable.

* Alphabetized language enum

* Update markdownhighlighter.h

Fix type